### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ SDKBOXは**command-line**、**eclipse**と**Android Studio**の3つAndroidプロ
 
 **2.1 Copy Files**
 
-* **plugin/android/libs**フォルダーから下記の**jar**ファイルをあなたのプロジェクトの**/libs**下にコピーしてください。
+* **.sdkbox/plugins/sdkbox-adcolony_vX.Y.Z/plugin/android/libs**フォルダーから下記の**jar**ファイルをあなたのプロジェクトの**/libs**下にコピーしてください。
 	* adcolony.jar
 	* PluginAdColony.jar
 	* sdkbox.jar


### PR DESCRIPTION
AndroidのManual Integrationの手順に出てくる `plugin/android/libs` が分かりにくいかもしれないので詳細に記載
これでも分からない人は分からないかな

> https://jira.gree-office.net/browse/ADCOLONY-19
>  2.1 Copy Filesの手順にて、plugin/android/libsフォルダーからjarファイル3点をコピーするとありますが、
> 「plugin/android/libs」がどこを示すのか分からなかったので、プロジェクトフォルダ内の「../cocos2d/cocos/platform/android/libcocos2dx/libs」内の同名のファイルをコピーしました。

↑間違ってる
